### PR TITLE
Add keyboard navigation

### DIFF
--- a/src/components/VueBootstrapTypeahead.vue
+++ b/src/components/VueBootstrapTypeahead.vue
@@ -16,6 +16,9 @@
         @focus="isFocused = true"
         @blur="handleBlur"
         @input="$emit('input', $event.target.value)"
+        @keyup.down="$emit('keyup.down', $event.target.value)"
+        @keyup.up="$emit('keyup.up', $event.target.value)"
+        @keyup.enter="$emit('keyup.enter', $event.target.value)"
         autocomplete="off"
       />
       <div v-if="$slots.append || append" class="input-group-append">

--- a/src/components/VueBootstrapTypeaheadList.vue
+++ b/src/components/VueBootstrapTypeaheadList.vue
@@ -5,6 +5,7 @@
       v-html="highlight(item.text)"
       :background-variant="backgroundVariant"
       :text-variant="textVariant"
+      :active="isListItemActive(id)"
       @click.native="handleHit(item, $event)"
     />
   </div>
@@ -54,6 +55,12 @@ export default {
     }
   },
 
+  data() {
+    return {
+      activeListItem: -1
+    }
+  },
+
   computed: {
     highlight() {
       return (text) => {
@@ -96,7 +103,39 @@ export default {
     handleHit(item, evt) {
       this.$emit('hit', item)
       evt.preventDefault()
+    },
+    isListItemActive(id) {
+      return this.activeListItem === id
+    },
+    resetActiveListItem() {
+      this.activeListItem = -1
+    },
+    selectNextListItem() {
+      if (this.activeListItem < this.matchedItems.length - 1) {
+        this.activeListItem++
+      } else {
+        this.resetActiveListItem()
+      }
+    },
+    selectPreviousListItem() {
+      if (this.activeListItem < 0) {
+        this.activeListItem = this.matchedItems.length - 1
+      } else {
+        this.activeListItem--
+      }
+    },
+    hitActiveListItem() {
+      if (this.activeListItem >= 0) {
+        this.$emit('hit', this.matchedItems[this.activeListItem])
+      }
     }
+  },
+
+  created() {
+    this.$parent.$on('input', this.resetActiveListItem)
+    this.$parent.$on('keyup.down', this.selectNextListItem)
+    this.$parent.$on('keyup.up', this.selectPreviousListItem)
+    this.$parent.$on('keyup.enter', this.hitActiveListItem)
   }
 }
 </script>

--- a/src/components/VueBootstrapTypeaheadListItem.vue
+++ b/src/components/VueBootstrapTypeaheadListItem.vue
@@ -2,8 +2,6 @@
   <a
     href="#"
     :class="textClasses"
-    @mouseover="active = true"
-    @mouseout="active = false"
   >
     <slot></slot>
   </a>
@@ -14,6 +12,9 @@ export default {
   name: 'VueBootstrapTypeaheadListItem',
 
   props: {
+    active: {
+      type: Boolean
+    },
     backgroundVariant: {
       type: String
     },
@@ -22,19 +23,13 @@ export default {
     }
   },
 
-  data() {
-    return {
-      active: false
-    }
-  },
-
   computed: {
     textClasses() {
-      let classes = ''
-      classes += this.active ? 'active' : ''
-      classes += this.backgroundVariant ? ` bg-${this.backgroundVariant}` : ''
-      classes += this.textVariant ? ` text-${this.textVariant}` : ''
-      return `vbst-item list-group-item list-group-item-action ${classes}`
+      const classes = ['vbst-item', 'list-group-item', 'list-group-item-action']
+      if (this.active) classes.push('active')
+      if (this.backgroundVariant) classes.push(`bg-${this.backgroundVariant}`)
+      if (this.textVariant) classes.push(`text-${this.textVariant}`)
+      return classes.join(' ')
     }
   }
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -17,7 +17,6 @@
           <vue-bootstrap-typeahead
             :data="countries"
             v-model="cntrySearch"
-            background-variant="light"
             :serializer="s => s.name"
             placeholder="Canada, United States, etc..."
             @hit="selectedCountry = $event"


### PR DESCRIPTION
#1 

- ListItem component: replaced the old `active` class on mouseover with a property (somehow helps #6)
- Typeahead component: added events on input key down: up, down, enter (somehow helps #7, will need documentation in the README)
- List component: added a data value `activeListItem` which goes from -1 to the length of the matchedItems, catch parent events to increment/decrement it and use it to set the active prop on list items 