### PR TITLE
maxMatches isn't passed to VueBootstrapTypeheadList

### DIFF
--- a/src/components/VueBootstrapTypeahead.vue
+++ b/src/components/VueBootstrapTypeahead.vue
@@ -32,6 +32,7 @@
       :data="formattedData"
       :background-variant="backgroundVariant"
       :text-variant="textVariant"
+      :maxMatches="maxMatches"
       :minMatchingChars="minMatchingChars"
       @hit="handleHit"
     >


### PR DESCRIPTION
maxMatches never propagates the value to the subcomponent VueBoostrapTypeheadList causing it to not update by overriding at the the VueBoostrapTypehead component level