### PR TITLE
fix: check for value at start and watch for external changes

### DIFF
--- a/src/components/VueBootstrapTypeahead.vue
+++ b/src/components/VueBootstrapTypeahead.vue
@@ -164,7 +164,7 @@ export default {
   data() {
     return {
       isFocused: false,
-      inputValue: ''
+      inputValue: this.value
     }
   },
 
@@ -174,6 +174,12 @@ export default {
     })
     this.$_ro.observe(this.$refs.input)
     this.$_ro.observe(this.$refs.list.$el)
+  },
+
+  watch: {
+    'value'(newValue) {
+      this.inputValue = newValue
+    }
   },
 
   beforeDestroy() {


### PR DESCRIPTION
Got this issue that you can't preset the value. This fixes it.

Demonstrated in this pen: https://codepen.io/raymondmuller/pen/pxgXzd

the value of 'query' is 'test', however the input does not reflect it.

also watching the value afterwards to make it respond to external changes