### PR TITLE
added Feature: :disable Property

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ maxMatches | `Number` | 10 | Maximum amount of list items to appear.
 minMatchingChars | `Number` | 2 | Minimum matching characters in query before the typeahead list appears
 prepend | `String` | | Text to be prepended to the `input-group`
 append | `String` | | Text to be appended to the `input-group`
+disabled | `Boolean` | false | Enable or disable input field
 
 ### Events
 Name | Description

--- a/src/components/VueBootstrapTypeahead.vue
+++ b/src/components/VueBootstrapTypeahead.vue
@@ -13,6 +13,7 @@
         :placeholder="placeholder"
         :aria-label="placeholder"
         :value="inputValue"
+        :disabled="disabled"
         @focus="isFocused = true"
         @blur="handleBlur"
         @input="handleInput($event.target.value)"
@@ -67,6 +68,10 @@ export default {
     },
     value: {
       type: String
+    },
+    disabled: {
+     type: Boolean,
+     default: false
     },
     data: {
       type: Array,


### PR DESCRIPTION
I was missing the feature to disable the input-field itself. Most vue bootstrap components that are using input-fields contain a :disabled property.