### PR TITLE
Set the default of value to empty string

### DIFF
--- a/src/components/VueBootstrapTypeahead.vue
+++ b/src/components/VueBootstrapTypeahead.vue
@@ -66,7 +66,8 @@ export default {
       validator: size => ['lg', 'sm'].indexOf(size) > -1
     },
     value: {
-      type: String
+      type: String,
+      default: ''
     },
     data: {
       type: Array,


### PR DESCRIPTION
This will fix a bug, i've came across, when giving an undefined value to v-model.

See: https://codepen.io/anon/pen/vPgeRM