### PR TITLE
Add showAll option to show all  data

### DIFF
--- a/src/components/VueBootstrapTypeahead.vue
+++ b/src/components/VueBootstrapTypeahead.vue
@@ -33,6 +33,7 @@
       :background-variant="backgroundVariant"
       :text-variant="textVariant"
       :minMatchingChars="minMatchingChars"
+      :showAll="showAll"
       @hit="handleHit"
     >
       <!-- pass down all scoped slots -->
@@ -93,7 +94,12 @@ export default {
     },
     placeholder: String,
     prepend: String,
-    append: String
+    append: String,
+    showAll: {
+      type: Boolean,
+      default: false
+    },
+
   },
 
   computed: {

--- a/src/components/VueBootstrapTypeaheadList.vue
+++ b/src/components/VueBootstrapTypeaheadList.vue
@@ -56,7 +56,11 @@ export default {
     minMatchingChars: {
       type: Number,
       default: 2
+    },
+    showAll: {
+      type: Boolean
     }
+
   },
 
   computed: {
@@ -81,7 +85,7 @@ export default {
         return []
       }
 
-      const re = new RegExp(this.escapedQuery, 'gi')
+      const re = new RegExp(this.showall ? "" : this.escapedQuery, "gi");
 
       // Filter, sort, and concat
       return this.data

--- a/src/components/VueBootstrapTypeaheadList.vue
+++ b/src/components/VueBootstrapTypeaheadList.vue
@@ -85,7 +85,7 @@ export default {
         return []
       }
 
-      const re = new RegExp(this.showall ? "" : this.escapedQuery, "gi");
+      const re = new RegExp(this.showAll ? "" : this.escapedQuery, "gi");
 
       // Filter, sort, and concat
       return this.data


### PR DESCRIPTION
I am using axios to update my listentries. I am searching a database with names. Sometimes i want to be able to search for part of the names e.g. "FirstNa LastNa" returns "FirstName Lastname" also. But it does not Match the querystring in the inputfield anymore, so typeahead does not display the (valid) response. I added an option "showAll" which is false as default. When switched "on" typeahead will display all responses in the list.

hope this helps somebody if needed.