### PR TITLE
Update scoped slot suggestion template

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,10 @@ for the suggestion `list-item`'s
 >
   <!-- htmlText is bound to the matched text derived from the serializer function -->
   <!-- data is bound to the matching array element in the data prop -->
-  <template slot="suggestion" slot-scope="{ data, htmlText }">
-    <span v-html="htmlText"></span>&nbsp;<small>{{ data.code }}</small>
+  <template v-slot:suggestion="slotProp">
+    <span v-html="slotProp.htmlText"></span>&nbsp;<small>{{ slotProp.data.code }}</small>
   </template>
+
 </vue-bootstrap-typeahead>
 ```
 


### PR DESCRIPTION
Update template example to use Vue 2.60+ syntax. See https://vuejs.org/v2/guide/components-slots.html#Scoped-Slots
(cherry picked from commit a9cfc7ec4a0a7afa866bee14304890b8b26c58d1)