### PR TITLE
#50-issue - Added a rawResults flag to VueBootstrapTypehead that enab…

### DIFF
--- a/src/components/VueBootstrapTypeahead.vue
+++ b/src/components/VueBootstrapTypeahead.vue
@@ -34,6 +34,7 @@
       :text-variant="textVariant"
       :minMatchingChars="minMatchingChars"
       @hit="handleHit"
+      :rawResults="rawResults"
     >
       <!-- pass down all scoped slots -->
       <template v-for="(slot, slotName) in $scopedSlots" :slot="slotName" slot-scope="{ data, htmlText }">
@@ -93,7 +94,8 @@ export default {
     },
     placeholder: String,
     prepend: String,
-    append: String
+    append: String,
+    rawResults: Boolean
   },
 
   computed: {

--- a/src/components/VueBootstrapTypeaheadList.vue
+++ b/src/components/VueBootstrapTypeaheadList.vue
@@ -56,6 +56,9 @@ export default {
     minMatchingChars: {
       type: Number,
       default: 2
+    },
+    rawResults: {
+      type: Boolean
     }
   },
 
@@ -77,6 +80,10 @@ export default {
     },
 
     matchedItems() {
+      if (this.rawResults) {
+        return this.data
+      }
+
       if (this.query.length === 0 || this.query.length < this.minMatchingChars) {
         return []
       }


### PR DESCRIPTION
Added a rawResults flag to VueBootstrapTypehead that enables it to show all the data results without filters in TypeheadList.
Actually I had the same issue as mentioned here: https://github.com/alexurquhart/vue-bootstrap-typeahead/issues/50 . I have a data from server, that is already processed and filtered as I need. So this will help me or somebody else to do the same thing - just show all the data in TypeheadList if they've already processed it by adding a flag rawResults to their component. Like this: 
<vue-bootstrap-typeahead
      :data="countries"
      v-model="cntrySearch"
      :serializer="s => s.name"
      placeholder="Canada, United States, etc..."
      @hit="handleHit"
      :rawResults="true"
/>
Without the flag or setting it to false will act as it is now.
P.S: I'm not really experienced contributor, so contact me please if I did something wrong and I'll be happy to fix myself up).