### PR TITLE
option to disable regex items matching

### DIFF
--- a/src/components/VueBootstrapTypeaheadList.vue
+++ b/src/components/VueBootstrapTypeaheadList.vue
@@ -77,6 +77,9 @@ export default {
     },
 
     matchedItems() {
+    
+      if (this.minMatchingChars === 0) return this.data
+    
       if (this.query.length === 0 || this.query.length < this.minMatchingChars) {
         return []
       }


### PR DESCRIPTION
Disable the regex items matching if minMatchingChar === 0. Useful when using with external services (like a geocoder) where all results are already filtered based on the search query.