### PR TITLE
Add justList property to only shows the data given

### DIFF
--- a/src/components/VueBootstrapTypeahead.vue
+++ b/src/components/VueBootstrapTypeahead.vue
@@ -34,6 +34,7 @@
       :text-variant="textVariant"
       :maxMatches="maxMatches"
       :minMatchingChars="minMatchingChars"
+      :justList="justList"
       @hit="handleHit"
     >
       <!-- pass down all scoped slots -->
@@ -91,6 +92,10 @@ export default {
     minMatchingChars: {
       type: Number,
       default: 2
+    },
+    justList: {
+      type: Boolean,
+      default: false
     },
     placeholder: String,
     prepend: String,

--- a/src/components/VueBootstrapTypeahead.vue
+++ b/src/components/VueBootstrapTypeahead.vue
@@ -34,7 +34,7 @@
       :text-variant="textVariant"
       :maxMatches="maxMatches"
       :minMatchingChars="minMatchingChars"
-      :justList="justList"
+      :showAllResults="showAllResults"
       @hit="handleHit"
     >
       <!-- pass down all scoped slots -->
@@ -93,7 +93,7 @@ export default {
       type: Number,
       default: 2
     },
-    justList: {
+    showAllResults: {
       type: Boolean,
       default: false
     },

--- a/src/components/VueBootstrapTypeaheadList.vue
+++ b/src/components/VueBootstrapTypeaheadList.vue
@@ -57,7 +57,7 @@ export default {
       type: Number,
       default: 2
     },
-    justList: {
+    showAllResults: {
       type: Boolean,
       default: false
     }
@@ -84,8 +84,8 @@ export default {
       if (this.query.length === 0 || this.query.length < this.minMatchingChars) {
         return []
       }
-      // If the user only just want to list the possible suggestions (e.g. the filter are on backend) the justList property is turn on
-      if (this.justList) {
+      // If the user only just want to list the possible suggestions (e.g. the filter are on backend) the showAllResults property is turn on
+      if (this.showAllResults) {
         return this.data.slice(0, this.maxMatches)
       }
 

--- a/src/components/VueBootstrapTypeaheadList.vue
+++ b/src/components/VueBootstrapTypeaheadList.vue
@@ -56,6 +56,10 @@ export default {
     minMatchingChars: {
       type: Number,
       default: 2
+    },
+    justList: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -79,6 +83,10 @@ export default {
     matchedItems() {
       if (this.query.length === 0 || this.query.length < this.minMatchingChars) {
         return []
+      }
+      // If the user only just want to list the possible suggestions (e.g. the filter are on backend) the justList property is turn on
+      if (this.justList) {
+        return this.data.slice(0, this.maxMatches)
       }
 
       const re = new RegExp(this.escapedQuery, 'gi')


### PR DESCRIPTION
This property is useful when your suggestions are filtered on backend. What happen if someone has typo on Canada word? the default matching of the plugin won't show you the Canada country. That's the reason that you can filter your suggestion from backend and only use this component to show the options.